### PR TITLE
Remove old players after world change

### DIFF
--- a/src/main/java/net/simpvp/PvPTeleport/DisableWorldCommand.java
+++ b/src/main/java/net/simpvp/PvPTeleport/DisableWorldCommand.java
@@ -45,6 +45,12 @@ public class DisableWorldCommand implements CommandExecutor {
 			sender.sendMessage("Disabling /world . . .");
 			is_disabled = true;
 
+			long currentTime = System.currentTimeMillis();
+			PvPTeleport.pvpLastReset = currentTime;
+
+			PvPTeleport.instance.getConfig().set("pvp_last_reset", currentTime);
+			PvPTeleport.instance.saveConfig();
+
 			World world = PvPTeleport.instance.getServer().getWorld("pvp");
 			for (Player p : world.getPlayers()) {
 				TeleportBack.teleportBack(p);

--- a/src/main/java/net/simpvp/PvPTeleport/PvPTeleport.java
+++ b/src/main/java/net/simpvp/PvPTeleport/PvPTeleport.java
@@ -7,6 +7,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 public class PvPTeleport extends JavaPlugin {
 
 	public static JavaPlugin instance;
+	public static long pvpLastReset = 0L;
 
 	public void onEnable() {
 		instance = this;
@@ -16,6 +17,13 @@ public class PvPTeleport extends JavaPlugin {
 		if (!dir.exists()) {
 			dir.mkdir();
 		}
+
+		if (!getConfig().isLong("pvp_last_reset")) {
+			getConfig().set("pvp_last_reset", 0L);
+			saveConfig();
+		}
+
+		pvpLastReset = getConfig().getLong("pvp_last_reset", 0L);
 
 		getCommand("world").setExecutor(new WorldCommand());
 		getCommand("pvplist").setExecutor(new PvPListCommand());

--- a/src/main/java/net/simpvp/PvPTeleport/PvPTransportation.java
+++ b/src/main/java/net/simpvp/PvPTeleport/PvPTransportation.java
@@ -100,6 +100,11 @@ public class PvPTransportation {
 				z = z_center;
 			}
 
+			/* World border math can produce block-edge coordinates,
+			* so we re-center them here */
+			x = Math.floor(x) + 0.5;
+			z = Math.floor(z) + 0.5;
+
 			spawnLoc.setX(x);
 			spawnLoc.setY(y);
 			spawnLoc.setZ(z);


### PR DESCRIPTION
- Removes players from the pvp world if they login in pvp following a world change. Rare case but has caused some deaths.

- Fixes block-centering issue caused by certain worldborder center/size values. (Block-edge spawns can be unsafe).